### PR TITLE
Make AcmeChallenge's challenge a unique value

### DIFF
--- a/letsencrypt/__init__.py
+++ b/letsencrypt/__init__.py
@@ -14,6 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-__version__ = '1.0.1'
+__version__ = '1.0.2'
 
 default_app_config = 'letsencrypt.apps.LetsEncryptConfig'

--- a/letsencrypt/migrations/0002_remove_challenge_duplicates.py
+++ b/letsencrypt/migrations/0002_remove_challenge_duplicates.py
@@ -1,0 +1,61 @@
+"""
+Copyright 2016 Peter Urda
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.db.models import Count
+
+
+def delete_duplicates(apps, schema_editor):
+    """
+    Find any AcmeChallenge duplicates and delete them
+
+    An AcmeChallenge is considered a duplicate if more than one
+    record has the same 'challenge' value as another.
+    """
+
+    AcmeChallenge = apps.get_model('letsencrypt', 'AcmeChallenge')
+    _ = schema_editor
+
+    dupes = (
+        AcmeChallenge.objects
+        .values('challenge')
+        .annotate(Count('id'))
+        .filter(id__count__gt=1)
+    )
+
+    for dupe_challenge in [item['challenge'] for item in dupes]:
+        dupes_to_delete = (
+            AcmeChallenge.objects.filter(challenge=dupe_challenge)[1:]
+            .values_list("id", flat=True)
+        )
+
+        AcmeChallenge.objects.filter(id__in=dupes_to_delete).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('letsencrypt', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=delete_duplicates,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/letsencrypt/migrations/0002_remove_challenge_duplicates.py
+++ b/letsencrypt/migrations/0002_remove_challenge_duplicates.py
@@ -17,7 +17,7 @@ limitations under the License.
 
 from __future__ import unicode_literals
 
-from django.db import migrations, models
+from django.db import migrations
 from django.db.models import Count
 
 

--- a/letsencrypt/migrations/0003_make_challenge_unique.py
+++ b/letsencrypt/migrations/0003_make_challenge_unique.py
@@ -1,0 +1,37 @@
+"""
+Copyright 2016 Peter Urda
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('letsencrypt', '0002_remove_challenge_duplicates'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='acmechallenge',
+            name='challenge',
+            field=models.TextField(
+                unique=True,
+                help_text='The identifier for this challenge'
+            ),
+        ),
+    ]

--- a/letsencrypt/models.py
+++ b/letsencrypt/models.py
@@ -28,6 +28,7 @@ class AcmeChallenge(models.Model):
 
     challenge = models.TextField(
         help_text='The identifier for this challenge',
+        unique=True,
     )
 
     response = models.TextField(

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-letsencrypt',
-    version='1.0.1',
+    version='1.0.2',
     packages=['letsencrypt'],
     include_package_data=True,
     license='Apache License, Version 2.0',


### PR DESCRIPTION
This PR fixes a bug that allows for duplicate challenges to be generated and served. Currently, if two or more `AcmeChallenge` objects share the same `challenge` value a `MultipleObjectsReturned` will be thrown when visiting their challenge link.

## Changes

- [x] Updated `version`
- [x] Created migrations:
  - [x] Data migration to remove duplicate
  - [x] Database migration to add `unique` to `challenge`
- [x] Tested against test app:
  - [x] Removed duplicates
  - [x] Prevents new duplicates
  - [x] Old object URL's work again.

## Related Commits, Issues, PR's

- Fixes #2 
