### PR TITLE
Require `pytz` for the library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,8 @@ branches:
   only:
     - master
     - develop
-    - /^release\/.$*/
+    - /^release\/.*$/
+    - /^support\/.*$/
 
 before_install:
   - echo Travis OS Name ... ${TRAVIS_OS_NAME}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # django-letsencrypt CHANGELOG
 
+## v1.0.8
+
+- Project Changes
+  - Require `pytz` for SQLite users.
+  - Update `travis` branch build targets.
+
 ## v1.0.7
 
-- Project changes
+- Project Changes
   - Final "feature" release of the 1.x branch. 2.0 will support `mysql`.
     This had to be done due to certain model upcoming model changes, and
     will result in a new set of migrations.

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ clean: # Clean up build, test, and other project artifacts
 	./htmlcov \
 	.coverage \
 	coverage.xml \
+	&& \
+	find . | grep -E "(__pycache__|\.pyc|\.pyo$$)" | xargs rm -rf \
 	&& :
 
 

--- a/letsencrypt/__init__.py
+++ b/letsencrypt/__init__.py
@@ -14,6 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-__version__ = '1.0.7'
+__version__ = '1.0.8'
 
 default_app_config = 'letsencrypt.apps.LetsEncryptConfig'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 coverage
 Django
 flake8
+pytz
 twine

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-letsencrypt',
-    version='1.0.7',
+    version='1.0.8',
     packages=['letsencrypt'],
     include_package_data=True,
     license='Apache License, Version 2.0',

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
     author_email='noreply@urda.cc',
     install_requires=[
         "Django>=1.8.16",
+        "pytz>=2016.10",
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
## Changes

- [x] Version Bump to 1.0.8
- [x] Fix `travis` branches `only` section
- [x] Include `pytz` as a project requirement. This is needed for `SQLite` users.
- [x] Updated `make clean` to clean up `pycache`, `pyc`, `pyo` files.