### PR TITLE
Set the `ordering` of ACME objects in Django admin page by `challenge`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v1.1.0
 
+- Project Changes
+  - Admin `ordering` for the Django admin page is now down by `challenge`
+
 ## v1.0.8
 
 - Project Changes

--- a/letsencrypt/admin.py
+++ b/letsencrypt/admin.py
@@ -65,6 +65,10 @@ class AcmeChallengeAdmin(admin.ModelAdmin):
         'updated_ts',
     ]
 
+    ordering = [
+        'challenge',
+    ]
+
     readonly_fields = [
         'id',
         'created_ts',


### PR DESCRIPTION
The `admin.py` for `ACME` challenges was missing an ordering value. We'll just order by `challenge` on the admin page.