### PR TITLE
v6.0.1 release commit

### DIFF
--- a/.github/workflows/testing-42.yaml
+++ b/.github/workflows/testing-42.yaml
@@ -21,7 +21,7 @@ jobs:
           - '3.11.14'
           - '3.10.19'
         django-version:
-          - '4.2.27'
+          - '4.2.28'
         database-target:
           - 'mysql'
           - 'postgres'

--- a/.github/workflows/testing-52.yaml
+++ b/.github/workflows/testing-52.yaml
@@ -23,7 +23,7 @@ jobs:
           - '3.11.14'
           - '3.10.19'
         django-version:
-          - '5.2.10'
+          - '5.2.11'
         database-target:
           - 'mysql'
           - 'postgres'

--- a/.github/workflows/testing-60.yaml
+++ b/.github/workflows/testing-60.yaml
@@ -21,7 +21,7 @@ jobs:
           - '3.13.11'
           - '3.12.12'
         django-version:
-          - '6.0.1'
+          - '6.0.2'
         database-target:
           - 'mysql'
           - 'postgres'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # django-letsencrypt CHANGELOG
 
+## v6.0.1
+
+There are no major project changes or code updates.
+This release aligns with recent Django releases and Python releases.
+
+- General Updates:
+  - Updated Django target versions against newer releases.
+  - Dropped `pytz` from the project. Projects using Python 3.9 or later are best served by using the timezone functionality now included in core Python and packages that work with it such as tzdata.
+
 ## v6.0.0
 
 This release aligns with recent Django releases and Python releases.

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ clean: # Clean up build, test, and other project artifacts
 
 .PHONY: version-check
 version-check: # Verify the project version string is correct across the project
-	@uv run ./scripts/version_manager.py check
+	@uv run ./scripts/version_manager.py $(or $(ARGS),check)
 
 .PHONY: version-check-django
 version-check-django: # Verify the project's Django version

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ supported so far:
   - `3.11` (with Django `5.2`, `4.2`)
   - `3.10` (with Django `5.2`, `4.2`)
 - Django Versions Supported:
-  - `6.0` minimum version `6.0.1`
-  - `5.2 LTS` minimum version `5.2.10`
-  - `4.2 LTS` minimum version `4.2.27`
+  - `6.0` minimum version `6.0.2`
+  - `5.2 LTS` minimum version `5.2.11`
+  - `4.2 LTS` minimum version `4.2.28`
 - Databases Supported:
   - `mysql`
   - `postgres`

--- a/letsencrypt/__init__.py
+++ b/letsencrypt/__init__.py
@@ -14,6 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-__version__ = '6.0.0'
+__version__ = '6.0.1'
 
 default_app_config = 'letsencrypt.apps.LetsEncryptConfig'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name='django-letsencrypt'
-version='6.0.0'
+version='6.0.1'
 description="A simple Django app to handle Let's Encrypt ACME challenges."
 readme = 'README.md'
 license = 'Apache-2.0'
@@ -44,8 +44,7 @@ classifiers = [
     'Topic :: Security',
 ]
 dependencies = [
-    'Django>=4.2.27',
-    'pytz>=2025.2',
+    'Django>=4.2.28',
 ]
 
 [project.urls]

--- a/scripts/testpypi_integration.sh
+++ b/scripts/testpypi_integration.sh
@@ -95,7 +95,7 @@ pip install \
 
 # Show what was installed
 echo "${PREFIX} Installed packages:"
-pip list | grep -E "(django|letsencrypt|pytz)"
+pip list | grep -E "(django|letsencrypt)"
 
 # Navigate to the example project
 cd "${WORK_DIR}/example_project"

--- a/tox.ini
+++ b/tox.ini
@@ -17,10 +17,9 @@ commands =
     make version-check-django
     make test-tox-entry
 deps =
-    django42: Django>=4.2.27,<5.0
-    django52: Django>=5.2.10,<6.0
-    django60: Django>=6.0.1,<7.0
-    pytz
+    django42: Django>=4.2.28,<5.0
+    django52: Django>=5.2.11,<6.0
+    django60: Django>=6.0.2,<7.0
     coverage
 allowlist_externals =
     make

--- a/uv.lock
+++ b/uv.lock
@@ -385,12 +385,11 @@ wheels = [
 
 [[package]]
 name = "django-letsencrypt"
-version = "6.0.0"
+version = "6.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "django", version = "5.2.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "django", version = "6.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "pytz" },
 ]
 
 [package.dev-dependencies]
@@ -407,10 +406,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "django", specifier = ">=4.2.27" },
-    { name = "pytz", specifier = ">=2025.2" },
-]
+requires-dist = [{ name = "django", specifier = ">=4.2.28" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -764,15 +760,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/fb/55d580352db26eb3d59ad50c64321ddfe228d3d8ac107db05387a2fadf3a/pytest_django-4.11.1.tar.gz", hash = "sha256:a949141a1ee103cb0e7a20f1451d355f83f5e4a5d07bdd4dcfdd1fd0ff227991", size = 86202, upload-time = "2025-04-03T18:56:09.338Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/ac/bd0608d229ec808e51a21044f3f2f27b9a37e7a0ebaca7247882e67876af/pytest_django-4.11.1-py3-none-any.whl", hash = "sha256:1b63773f648aa3d8541000c26929c1ea63934be1cfa674c76436966d73fe6a10", size = 25281, upload-time = "2025-04-03T18:56:07.678Z" },
-]
-
-[[package]]
-name = "pytz"
-version = "2025.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Due to multiple reported CVE's, and updated releases from Django we need to ship `v6.0.1`.